### PR TITLE
Fix/partials request data

### DIFF
--- a/ajax_views/static/ajax_views/partials.jquery.js
+++ b/ajax_views/static/ajax_views/partials.jquery.js
@@ -21,7 +21,6 @@
             var $partialContainer = $($elem.data('partial'));
             var partialUrl = $elem.data('partial-url');
             var partialData = $elem.data('partial-data') || {};
-            console.log(partialData);
             $elem.on('click', function () {
 
                 // redefine previous content

--- a/ajax_views/static/ajax_views/partials.jquery.js
+++ b/ajax_views/static/ajax_views/partials.jquery.js
@@ -21,7 +21,7 @@
             var $partialContainer = $($elem.data('partial'));
             var partialUrl = $elem.data('partial-url');
             var partialData = $elem.data('partial-data') || {};
-
+            console.log(partialData);
             $elem.on('click', function () {
 
                 // redefine previous content
@@ -32,7 +32,7 @@
                 }
 
                 $elem.trigger('partial:loading', [$partialContainer]);
-
+                partialData = $elem[0].dataset.partialData || {}; // Repopulate the partialData in case it has been changed after the initial render.
                 self.request(partialUrl, partialData).done(function (data) {
 
                     self.injectPartial($partialContainer, data.content).done(function() {


### PR DESCRIPTION
Repopulate the partialData in case it has been changed after the initial render. This is important for cases where the 'data-partial-data' attribute is dynamically changed via JavaScript p/ example.